### PR TITLE
Create logspout-papertrail image to communicate over TLS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM gliderlabs/logspout:master
+MAINTAINER Squaremouth, Inc. <devops@squaremouth.com>
+
+RUN apk update && apk add curl && rm -rf /var/cache/apk/*
+
+RUN curl https://papertrailapp.com/tools/papertrail-bundle.pem > papertrail-bundle.pem
+RUN cp papertrail-bundle.pem /etc/ssl/certs/ca-certificates.crt
+RUN cp papertrail-bundle.pem /etc/ssl/ca-bundle.pem
+RUN chmod 644 /etc/ssl/certs/ca-certificates.crt
+RUN chmod 644 /etc/ssl/ca-bundle.pem
+RUN rm papertrail-bundle.pem

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # logspout-papertrail
+
+Logspout is a log router for Docker containers that run inside Docker. This repo creates a papertrail specific images when using the TLS logspout adapter.
+This image could still be used with the UDP and TCP adapters to any syslog server.  Any secure (TLS) transport protocol will only be available to talk to papertrail.
+
+## Getting logspout-papertrail
+
+```
+docker pull squaremouth/logspout-papertrail
+```
+
+## Using logspout-papertrail
+
+#### Route all container output to remote syslog
+The simplest way to use logspout-papertrail is to just take all logs and
+ship to a remote syslog.  Just pass a syslog URI (or several comma
+separated URIs) as the command.  Also, we always mount the Docker Unix
+socket with `-v` to `/tmp/docker.sock`:
+
+```
+docker run --name="logspout" \
+  --volume=/var/run/docker.sock:/tmp/docker.sock \
+  -e 'SYSLOG_HOSTNAME=node.example.com' \
+  squaremouth/logspout-papertrail \
+  syslog+tls://logs.papertrailapp.com:55555
+```

--- a/modules.go
+++ b/modules.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	_ "github.com/gliderlabs/logspout/adapters/raw"
+	_ "github.com/gliderlabs/logspout/adapters/syslog"
+	_ "github.com/gliderlabs/logspout/httpstream"
+	_ "github.com/gliderlabs/logspout/routesapi"
+	_ "github.com/gliderlabs/logspout/transports/tcp"
+	_ "github.com/gliderlabs/logspout/transports/tls"
+	_ "github.com/gliderlabs/logspout/transports/udp"
+)


### PR DESCRIPTION
In order to create a logspout container to communicate over TLS to
papertrail this commit creates a `Dockerfile` to build a
`logspout-papertrail` docker image.  This commit creates a `Dockerfile`
based on the [Custom Logspout Builds](https://github.com/gliderlabs/logspout/tree/master/custom) with
the papertrail cert overwriting the CA-Certs on the image, making this
image exclusively only able to communicate over TLS to papertrail.  This
commit also updates the `README.md` for directions on using the image.
